### PR TITLE
OCI Data model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -39,7 +39,7 @@ type ConfigGit struct {
 // ConfigLFS is an OCI manifest config, containing information about which commits an LFS file is associated with.
 type ConfigLFS struct {
 	// Refs map Git references to layers containing LFS files.
-	Refs map[string][]string `json:"commits"`
+	Refs map[string][]string `json:"refs"`
 }
 
 // ReferenceInfo holds informations about Git references stored in bundle layers.

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -4,24 +4,16 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
+// Git OCI artifacts.
 const (
 	// ArtifactTypeGitManifest is the artifact type for an Git manifest.
 	ArtifactTypeGitManifest = "application/vnd.act3-ai.git.repo.v1+json"
 
-	// ArtifactTypeLFSManifest is the artifact type for an Git LFS manifest.
-	ArtifactTypeLFSManifest = "application/vnd.act3-ai.git-lfs.repo.v1+json"
-
 	// MediaTypeGitConfig is the media type for a Git config.
 	MediaTypeGitConfig = "application/vnd.act3-ai.git.config.v1+json"
 
-	// MediaTypeLFSConfig is the media type for a Git LFS config.
-	MediaTypeLFSConfig = "application/vnd.act3-ai.git-lfs.config.v1+json"
-
 	// MediaTypePackLayer is the media type for a Git packfile stored as an OCI layer.
 	MediaTypePackLayer = "application/vnd.act3-ai.git.pack.v1"
-
-	// MediaTypeLFSLayer is the media type used for Git LFS layers.
-	MediaTypeLFSLayer = "application/vnd.act3-ai.git-lfs.object.v1"
 
 	// AnnotationGitRemoteOCIVersion is the key for the annotation to denote the git-remote-oci version used during the most recent operation.
 	AnnotationGitRemoteOCIVersion = "vnd.act3-ai.git-remote-oci.version"
@@ -34,14 +26,9 @@ type Commit string
 type ConfigGit struct {
 	// Heads map Git head references to commit OID and layer digest pairs.
 	Heads map[string]ReferenceInfo `json:"heads"`
+
 	// Tags map Git tag references to commit OID and layer digest pairs.
 	Tags map[string]ReferenceInfo `json:"tags"`
-}
-
-// ConfigLFS is an OCI manifest config, containing information about which commits an LFS file is associated with.
-type ConfigLFS struct {
-	// Refs map Git references to layers containing LFS files.
-	Refs map[string][]string `json:"refs"`
 }
 
 // ReferenceInfo holds informations about Git references stored in bundle layers.
@@ -52,3 +39,21 @@ type ReferenceInfo struct {
 	// OCI layer, the packfile containing Commit
 	Layer digest.Digest `json:"layer"`
 }
+
+// LFS OCI artifacts.
+// const (
+// 	// ArtifactTypeLFSManifest is the artifact type for an Git LFS manifest.
+// 	ArtifactTypeLFSManifest = "application/vnd.act3-ai.git-lfs.repo.v1+json"
+
+// 	// MediaTypeLFSConfig is the media type for a Git LFS config.
+// 	MediaTypeLFSConfig = "application/vnd.act3-ai.git-lfs.config.v1+json"
+
+// 	// MediaTypeLFSLayer is the media type used for Git LFS layers.
+// 	MediaTypeLFSLayer = "application/vnd.act3-ai.git-lfs.object.v1"
+// )
+
+// ConfigLFS is an OCI manifest config, containing information about which commits an LFS file is associated with.
+// type ConfigLFS struct {
+// 	// Refs map Git references to layers containing LFS files.
+// 	Refs map[string][]string `json:"refs"`
+// }

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -32,8 +32,10 @@ type Commit string
 
 // ConfigGit is an OCI manifest config, containing information about a Git repository's references.
 type ConfigGit struct {
-	// Refs map Git references to commit OID and layer digest pairs.
-	Refs map[string]ReferenceInfo `json:"refs"`
+	// Heads map Git head references to commit OID and layer digest pairs.
+	Heads map[string]ReferenceInfo `json:"heads"`
+	// Tags map Git tag references to commit OID and layer digest pairs.
+	Tags map[string]ReferenceInfo `json:"tags"`
 }
 
 // ConfigLFS is an OCI manifest config, containing information about which commits an LFS file is associated with.

--- a/pkg/oci/types.go
+++ b/pkg/oci/types.go
@@ -1,0 +1,52 @@
+package oci
+
+import (
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	// ArtifactTypeGitManifest is the artifact type for an Git manifest.
+	ArtifactTypeGitManifest = "application/vnd.act3-ai.git.repo.v1+json"
+
+	// ArtifactTypeLFSManifest is the artifact type for an Git LFS manifest.
+	ArtifactTypeLFSManifest = "application/vnd.act3-ai.git-lfs.repo.v1+json"
+
+	// MediaTypeGitConfig is the media type for a Git config.
+	MediaTypeGitConfig = "application/vnd.act3-ai.git.config.v1+json"
+
+	// MediaTypeLFSConfig is the media type for a Git LFS config.
+	MediaTypeLFSConfig = "application/vnd.act3-ai.git-lfs.config.v1+json"
+
+	// MediaTypePackLayer is the media type for a Git packfile stored as an OCI layer.
+	MediaTypePackLayer = "application/vnd.act3-ai.git.pack.v1"
+
+	// MediaTypeLFSLayer is the media type used for Git LFS layers.
+	MediaTypeLFSLayer = "application/vnd.act3-ai.git-lfs.object.v1"
+
+	// AnnotationGitRemoteOCIVersion is the key for the annotation to denote the git-remote-oci version used during the most recent operation.
+	AnnotationGitRemoteOCIVersion = "vnd.act3-ai.git-remote-oci.version"
+)
+
+// Commit represents a Git commit object identifier (OID), a SHA-1 hash.
+type Commit string
+
+// ConfigGit is an OCI manifest config, containing information about a Git repository's references.
+type ConfigGit struct {
+	// Refs map Git references to commit OID and layer digest pairs.
+	Refs map[string]ReferenceInfo `json:"refs"`
+}
+
+// ConfigLFS is an OCI manifest config, containing information about which commits an LFS file is associated with.
+type ConfigLFS struct {
+	// Refs map Git references to layers containing LFS files.
+	Refs map[string][]string `json:"commits"`
+}
+
+// ReferenceInfo holds informations about Git references stored in bundle layers.
+type ReferenceInfo struct {
+	// Commit pointed to by a reference
+	Commit Commit `json:"commit"`
+
+	// OCI layer, the packfile containing Commit
+	Layer digest.Digest `json:"layer"`
+}


### PR DESCRIPTION
Closes #17 

Storing Git references separately, as done by Git with `.git/ref/heas/...`/`.git/refs/tags/...`, seems to be ideal. Comparing to ace-dt, largely refs are handled either altogether or it's reasonable to get a fully-qualified reference; i.e. we know if a ref is a tag or head ref.

Largely, the data model is the same barring the change to packfiles. However, I believe spending the time to rethink the model has been worthwhile. It is still subject to change if opportunity for optimizations are found.

LFS portion of the data model still needs work.

